### PR TITLE
fix: update nodejs version to latest

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -2,7 +2,7 @@ service: packt-sample-lambda-api
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
   memorySize: 128
   stage: dev
   region: eu-west-1


### PR DESCRIPTION
NodeJS 6 gives this error message:
An error occurred: GetDashauthorsLambdaFunction - The runtime parameter
of nodejs6.10 is no longer supported for creating or updating AWS Lambda
functions. We recommend you use the new runtime (nodejs10.x) while
creating or updating functions.